### PR TITLE
Make Maxretry Handler only retry per-queue.

### DIFF
--- a/examples/max_retry_handler.rb
+++ b/examples/max_retry_handler.rb
@@ -4,8 +4,25 @@ require 'sneakers/runner'
 require 'sneakers/handlers/maxretry'
 require 'logger'
 
-Sneakers.configure(:handler => Sneakers::Handlers::Maxretry, :workers => 1, :threads => 1, :prefetch => 1)
-Sneakers.logger.level = Logger::INFO
+Sneakers.configure(:handler => Sneakers::Handlers::Maxretry,
+                   :workers => 1,
+                   :threads => 1,
+                   :prefetch => 1,
+                   :exchange => 'sneakers',
+                   :exchange_type => 'topic',
+                   :routing_key => ['#', 'something'],
+                   :durable => true,
+                   )
+Sneakers.logger.level = Logger::DEBUG
+
+WORKER_OPTIONS = {
+  :ack => true,
+  :threads => 1,
+  :prefetch => 1,
+  :timeout_job_after => 60,
+  :heartbeat => 5,
+  :retry_timeout => 5000
+}
 
 # Example of how to write a retry worker. If your rabbit system is empty, then
 # you must run this twice. Once to setup the exchanges, queues and bindings a
@@ -17,32 +34,45 @@ Sneakers.logger.level = Logger::INFO
 class MaxRetryWorker
   include Sneakers::Worker
   from_queue 'downloads',
-             :ack => true,
-             :threads => 1,
-             :prefetch => 1,
-             :timeout_job_after => 60,
-             :exchange => 'sneakers',
-             :heartbeat => 5,
-             :arguments => {
-              :'x-dead-letter-exchange' => 'sneakers-retry'
-             }
+      WORKER_OPTIONS.merge({
+                             :arguments => {
+                               :'x-dead-letter-exchange' => 'downloads-retry'
+                             },
+                           })
 
   def work(msg)
-
-    puts "Got message #{msg} and rejecting now"
+    logger.info("MaxRetryWorker rejecting msg: #{msg.inspect}")
 
     # We always want to reject to see if we do the proper timeout
     reject!
+  end
+end
 
+# Example of a worker on the same exchange that does not fail, so it should only
+# see the message once.
+class SucceedingWorker
+  include Sneakers::Worker
+  from_queue 'uploads',
+      WORKER_OPTIONS.merge({
+                             :arguments => {
+                               :'x-dead-letter-exchange' => 'uploads-retry'
+                             },
+                           })
+
+  def work(msg)
+    logger.info("SucceedingWorker succeeding on msg: #{msg.inspect}")
+    ack!
   end
 end
 
 messages = 1
 puts "feeding messages in"
 messages.times {
-  MaxRetryWorker.enqueue("{}")
+  Sneakers.publish(" -- message -- ",
+                   :to_queue => 'anywhere',
+                   :persistence => true)
 }
 puts "done"
 
-r = Sneakers::Runner.new([ MaxRetryWorker ])
+r = Sneakers::Runner.new([MaxRetryWorker, SucceedingWorker])
 r.run

--- a/lib/sneakers/handlers/maxretry.rb
+++ b/lib/sneakers/handlers/maxretry.rb
@@ -4,51 +4,76 @@ module Sneakers
     # Maxretry uses dead letter policies on Rabbitmq to requeue and retry
     # messages after failure (rejections, errors and timeouts). When the maximum
     # number of retries is reached it will put the message on an error queue.
+    # This handler will only retry at the queue level. To accomplish that, the
+    # setup is a bit complex.
+    #
+    # Input:
+    #   worker_exchange (eXchange)
+    #   worker_queue (Queue)
+    # We create:
+    #   worker_queue-retry - (X) where we setup the worker queue to dead-letter.
+    #   worker_queue-retry - (Q) queue bound to ^ exchange, dead-letters to
+    #                        worker_queue-retry-requeue.
+    #   worker_queue-error - (X) where to send max-retry failures
+    #   worker_queue-error - (Q) bound to worker_queue-error.
+    #   worker_queue-retry-requeue - (X) exchange to bind worker_queue to for
+    #                                requeuing directly to the worker_queue.
+    #
+    # This requires that you setup arguments to the worker queue to line up the
+    # dead letter queue. See the example for more information.
+    #
+    # Many of these can be override with options:
+    # - retry_exchange - sets retry exchange & queue
+    # - retry_error_exchange - sets error exchange and queue
+    # - retry_requeue_exchange - sets the exchange created to re-queue things
+    #   back to the worker queue.
     #
     class Maxretry
 
-      def initialize(channel, opts)
+      def initialize(channel, queue, opts)
+        @worker_queue_name = queue.name
+        Sneakers.logger.debug do
+          "Creating a Maxretry handler for queue(#{@worker_queue_name}),"\
+          " opts(#{opts})"
+        end
+
         @channel = channel
         @opts = opts
 
-        # If there is no retry exchange specified, use #{exchange}-retry
-        retry_name = @opts[:retryexchange] || "#{@opts[:exchange]}-retry"
+        # Construct names, defaulting where suitable
+        retry_name = @opts[:retry_exchange] || "#{@worker_queue_name}-retry"
+        error_name = @opts[:retry_error_exchange] || "#{@worker_queue_name}-error"
+        requeue_name = @opts[:retry_requeue_exchange] || "#{@worker_queue_name}-retry-requeue"
 
-        # Create the retry exchange as a durable topic so we retain original routing keys but bind the queue using a wildcard
-        retry_exchange = @channel.exchange( retry_name,
-                                            :type => 'topic',
-                                            :durable => 'true')
+        # Create the exchanges
+        @retry_exchange, @error_exchange, @requeue_exchange = [retry_name, error_name, requeue_name].map do |name|
+          Sneakers.logger.debug { "Creating exchange #{name} for retry handler on worker queue #{@worker_queue_name}" }
+          @channel.exchange(name,
+                            :type => 'topic',
+                            :durable => opts[:durable])
+        end
 
-        # Create the retry queue with the same name as the retry exchange and a dead letter exchange
-        # The dead letter exchange is the default exchange and the ttl can be from the opts or defaults to 60 seconds
-        # TODO: respect @opts[:durable]? Are there cases where you want the
-        # retry and error exchanges to match the originating exchange?
-        retry_queue = @channel.queue( retry_name,
-                                      :durable => 'true',
-                                      :arguments => {
-                                        :'x-dead-letter-exchange' => @opts[:exchange],
-                                        :'x-message-ttl' => @opts[:retry_timeout] || 60000
-                                    })
+        # Create the queues and bindings
+        Sneakers.logger.debug do
+          "Creating queue #{retry_name}, dead lettering to #{requeue_name}"
+        end
+        @retry_queue = @channel.queue(retry_name,
+                                     :durable => opts[:durable],
+                                     :arguments => {
+                                       :'x-dead-letter-exchange' => requeue_name,
+                                       :'x-message-ttl' => @opts[:retry_timeout] || 60000
+                                     })
+        @retry_queue.bind(@retry_exchange, :routing_key => '#')
 
-        # Bind the retry queue to the retry topic exchange with a wildcard
-        retry_queue.bind(retry_exchange, :routing_key => '#')
+        Sneakers.logger.debug do
+          "Creating queue #{error_name}"
+        end
+        @error_queue = @channel.queue(error_name,
+                                      :durable => opts[:durable])
+        @error_queue.bind(@error_exchange, :routing_key => '#')
 
-        ## Setup the error queue
-
-        # If there is no error exchange specified, use #{exchange}-error
-        error_name = @opts[:errorexchange] || "#{@opts[:exchange]}-error"
-
-        # Create the error exchange as a durable topic so we retain original routing keys but bind the queue using a wildcard
-        @error_exchange = @channel.exchange(error_name,
-                                            :type => 'topic',
-                                            :durable => 'true')
-
-        # Create the error queue with the same name as the error exchange
-        error_queue = @channel.queue( error_name,
-                                      :durable => 'true')
-
-        # Bind the error queue to the error topic exchange with a wildcard
-        error_queue.bind(@error_exchange, :routing_key => '#')
+        # Finally, bind the worker queue to our requeue exchange
+        queue.bind(@requeue_exchange, :routing_key => '#')
 
         @max_retries = @opts[:retry_max_times] || 5
 
@@ -63,8 +88,12 @@ module Sneakers
         # Note to readers, the count of the x-death will increment by 2 for each
         # retry, once for the reject and once for the expiration from the retry
         # queue
-        if requeue || ((failure_count(props[:headers]) + 1) < @max_retries)
-          # We call reject which will route the message to the x-dead-letter-exchange (ie. retry exchange) on the queue
+        if requeue || ((failure_count(props[:headers]) + 1) <= @max_retries)
+          # We call reject which will route the message to the
+          # x-dead-letter-exchange (ie. retry exchange)on the queue
+          Sneakers.logger.debug do
+            "Retrying failure, count #{failure_count(props[:headers]) + 1}, headers #{props[:headers]}"
+          end unless requeue # This is only relevant if we're in the failure path.
           @channel.reject(hdr.delivery_tag, requeue)
           # TODO: metrics
         else
@@ -100,7 +129,7 @@ module Sneakers
           0
         else
           headers['x-death'].select do |x_death|
-            x_death['queue'] == @opts[:exchange]
+            x_death['queue'] == @worker_queue_name
           end.count
         end
       end

--- a/lib/sneakers/handlers/oneshot.rb
+++ b/lib/sneakers/handlers/oneshot.rb
@@ -1,7 +1,7 @@
 module Sneakers
   module Handlers
     class Oneshot
-      def initialize(channel, opts)
+      def initialize(channel, queue, opts)
         @channel = channel
         @opts = opts
       end

--- a/lib/sneakers/worker.rb
+++ b/lib/sneakers/worker.rb
@@ -4,15 +4,15 @@ require 'timeout'
 
 module Sneakers
   module Worker
-    attr_reader :queue, :id
+    attr_reader :queue, :id, :opts
 
     # For now, a worker is hardly dependant on these concerns
     # (because it uses methods from them directly.)
     include Concerns::Logging
     include Concerns::Metrics
 
-    def initialize(queue=nil, pool=nil, opts=nil)
-      opts = self.class.queue_opts
+    def initialize(queue = nil, pool = nil, opts = {})
+      opts = opts.merge(self.class.queue_opts || {})
       queue_name = self.class.queue_name
       opts = Sneakers::Config.merge(opts)
 

--- a/spec/sneakers/sneakers_spec.rb
+++ b/spec/sneakers/sneakers_spec.rb
@@ -23,6 +23,7 @@ describe Sneakers do
     it 'should configure itself' do
       Sneakers.configure
       Sneakers.logger.wont_be_nil
+      Sneakers.configured?.must_equal(true)
     end
   end
 


### PR DESCRIPTION
This required a bit of a more complicated setup, but before this change,
the retry was retrying failures to the exchange which meant if you had a
fanout exchange, every queue would see the retry, not just the queue
that the failure occurred upon. To fix this, I created another exchange
and bound the queue you're retrying on to this one (in addition to the
exchange it was currently bound to). This allows us to put the retry
dead lettering to it and it will ONLY send the message to the queue
you're attempting retry on. Updated the example to demonstrate this more
clearly.

As part of this I made a couple of changes:
- Add another argument to handler constructor
- Use worker config when creating the handler.
- Fix bug in worker where it didn't respect incoming options. This
  didn't look to be used anywhere.
