### PR TITLE
Improve logging in Maxretry handler and fix fallthrough metric in worker

### DIFF
--- a/lib/sneakers/worker.rb
+++ b/lib/sneakers/worker.rb
@@ -85,7 +85,7 @@ module Sneakers
           else
             handler.noop(hdr, props, msg)
           end
-          metrics.increment("work.#{self.class.name}.handled.#{res || 'reject'}")
+          metrics.increment("work.#{self.class.name}.handled.#{res || 'noop'}")
         end
 
         metrics.increment("work.#{self.class.name}.ended")

--- a/spec/sneakers/worker_spec.rb
+++ b/spec/sneakers/worker_spec.rb
@@ -348,7 +348,13 @@ describe Sneakers::Worker do
     it 'should be able to meter rejects' do
       mock(@w.metrics).increment("foobar").once
       mock(@w.metrics).increment("work.MetricsWorker.handled.reject").once
-      @w.do_work(@header, nil, nil, @handler)
+      @w.do_work(@header, nil, :reject, @handler)
+    end
+
+    it 'should be able to meter requeue' do
+      mock(@w.metrics).increment("foobar").once
+      mock(@w.metrics).increment("work.MetricsWorker.handled.requeue").once
+      @w.do_work(@header, nil, :requeue, @handler)
     end
 
     it 'should be able to meter errors' do
@@ -361,6 +367,12 @@ describe Sneakers::Worker do
       mock(@w.metrics).increment("work.MetricsWorker.handled.timeout").once
       mock(@w).work('msg'){ sleep 10 }
       @w.do_work(@header, nil, 'msg', @handler)
+    end
+
+    it 'defaults to noop when no response is specified' do
+      mock(@w.metrics).increment("foobar").once
+      mock(@w.metrics).increment("work.MetricsWorker.handled.noop").once
+      @w.do_work(@header, nil, nil, @handler)
     end
   end
 


### PR DESCRIPTION
We needed some more insight into when a worker was retrying a job. Would
be nice to have stats too, but that really requires that these handlers
also have access to the worker. I think eventually we'll replace the
exchange and queue with the worker as an argument. Until then, this
logging should give us enough information to know how often it's
happening and possibly why.

Also the fallthrough case is noop when Sneakers cannot interpret the
response. The metric being collected was retry which was wrong as the
handler's retry method was not called and instead the noop method was.
Better to keep these two in line.
